### PR TITLE
WIP for multi part errors

### DIFF
--- a/openapi3/errors.go
+++ b/openapi3/errors.go
@@ -1,0 +1,16 @@
+package openapi3
+
+import "bytes"
+
+// MultiError is a collection of errors, intended for when
+// multiple issues need to be reported upstream
+type MultiError []error
+
+func (me MultiError) Error() string {
+	buff := &bytes.Buffer{}
+	for _, e := range me {
+		buff.WriteString(e.Error())
+		buff.WriteString(" | ")
+	}
+	return buff.String()
+}


### PR DESCRIPTION
I spoke with the kin-openapi maintainer, and he said he is open to reviewing a PR for this. There were already error types which encapsulated the information we need (field name and reason). I piggy back off of this. This should also allow an easier migration path for anyone parsing these errors. Essentially I am just accumulating the existing errors in a simple custom type vs. creating a whole new type.

This will result in some type juggling as you will see in my sample invproxy PR counterpart. Wanting to get some early feedback on the approach before I send the changes to the upstream